### PR TITLE
Add credits_left to TestObject

### DIFF
--- a/gtmetrix/interface.py
+++ b/gtmetrix/interface.py
@@ -23,6 +23,7 @@ class _TestObject(object):
                                os.path.join(settings.GTMETRIX_REST_API_URL, test_id))
         self.test_id = test_id
         self.state = self.STATE_QUEUED
+        self.credits_left = 0
         self.auth = auth
         self.results = {}
         self.resources = {}


### PR DESCRIPTION
credits_left was added to the API in June and apparently now results in an error:

File ".../lib/python2.7/site-packages/gtmetrix/interface.py", line 83, in start_test
    return _TestObject(self.auth, **response_data)
TypeError: __init__() got an unexpected keyword argument 'credits_left'